### PR TITLE
update heroku url to point to github pages site

### DIFF
--- a/src/components/iconsRow/index.js
+++ b/src/components/iconsRow/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { faGitSquare, faNpm } from "@fortawesome/free-brands-svg-icons";
+import { faGithub, faNpm, faReadme } from "@fortawesome/free-brands-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import "./iconsRow.scss";
 
@@ -10,16 +10,26 @@ const IconsRow = () => {
         <a
           target="_blank"
           rel="noopener noreferrer"
+          title="github"
           href="https://github.com/bronz3beard/react-matrix#react-matrix"
         >
-          <FontAwesomeIcon size="3x" color="#77B244" icon={faGitSquare} />
+          <FontAwesomeIcon size="3x" color="#77B244" icon={faGithub} />
         </a>
         <a
           target="_blank"
           rel="noopener noreferrer"
+          title="npm"
           href="https://www.npmjs.com/package/react-data-matrix"
         >
           <FontAwesomeIcon size="3x" color="#77B244" icon={faNpm} />
+        </a>
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          title="README.md"
+          href="https://github.com/bronz3beard/react-matrix#readme"
+        >
+          <FontAwesomeIcon size="3x" color="#77B244" icon={faReadme} />
         </a>
       </div>
     </div>


### PR DESCRIPTION
Summary of the new changes, feature.
Some minor DX changes, updated package.json and scripts added new website for hosting demo.

Please list if any, dependencies that are required for this change.
- new dep gh-pages @latest

## [0.2.0] - 16-05-2023
### Added
- new web page for hosting demo
- added readme icon
- added gh-pages dependency

### Changed
- update moved all dependencies into devDependencies these are not needed for the distribution of the package
- update DX minor changes 
- updated footer
- updated package.json

### Fixed
- [X] New feature (non-breaking change which adds functionality)
    - fixed incorrect icon for github
